### PR TITLE
generalize to compile on mac

### DIFF
--- a/solvers/CMakeLists.txt
+++ b/solvers/CMakeLists.txt
@@ -19,7 +19,7 @@ if (gurobi_FOUND AND eigen3_FOUND)
 	pods_install_headers(fastQP.h gurobiQP.h DESTINATION drake)
 	pods_install_pkg_config_file(drake-qp
 	    LIBS -ldrakeQP
-	    REQUIRES gurobi 
+	    REQUIRES gurobi
 	    VERSION 0.0.1)
 
 endif()
@@ -28,11 +28,9 @@ pods_find_pkg_config(snopt_cpp)
 
 
 if(snopt_cpp_FOUND)
-	set(GFORTRAN_LIBRARY ${MATLAB_ROOT}/sys/os/glnxa64/libgfortran.so.3)
+	find_library(GFORTRAN_LIBRARY NAMES gfortran libgfortran PATHS ${MATLAB_ROOT}/sys/os/*/)
   add_mex(NonlinearProgramSnoptmex NonlinearProgramSnoptmex.cpp)
-  pods_use_pkg_config_packages(NonlinearProgramSnoptmex snopt_cpp)	
+  pods_use_pkg_config_packages(NonlinearProgramSnoptmex snopt_cpp)
   set_target_properties(NonlinearProgramSnoptmex PROPERTIES COMPILE_FLAGS -fPIC)
 	target_link_libraries(NonlinearProgramSnoptmex ${GFORTRAN_LIBRARY})
 endif()
-
-

--- a/solvers/NonlinearProgramSnoptmex.cpp
+++ b/solvers/NonlinearProgramSnoptmex.cpp
@@ -99,7 +99,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
   char Prob[200]="";
 
   snopt::integer minrw,miniw,mincw;
-  snopt::integer lenrw = 10000000, leniw = 500000, lencw = 500; 
+  snopt::integer lenrw = 10000000, leniw = 500000, lencw = 500;
   snopt::doublereal* rw = (snopt::doublereal*) std::calloc(lenrw,sizeof(snopt::doublereal));
   snopt::integer* iw = (snopt::integer*) std::calloc(leniw,sizeof(snopt::integer));
   char cw[8*lencw];
@@ -130,8 +130,8 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
   }
   snopt::doublereal ObjAdd = static_cast<snopt::doublereal>(mxGetScalar(prhs[6]));
   snopt::integer ObjRow = static_cast<snopt::integer>(mxGetScalar(prhs[7]));
-  
-  
+
+
   snopt::integer iSumm = -1;
   snopt::integer iPrint = 15;
 
@@ -141,18 +141,18 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
 
   mxArray* pprint_name = mxGetField(prhs[13],0,"print");
   int print_file_name_len = mxGetNumberOfElements(pprint_name)+1;
-  char* print_file_name = new char[print_file_name_len]; 
+  char* print_file_name = new char[print_file_name_len];
   if(print_file_name_len != 0)
   {
 		char strOpt10[200] = "Major print level";
 		strOpt_len = strlen(strOpt10);
 		snopt::integer major_print_level = 11;
-		snopt::snseti_(strOpt10,&major_print_level,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+		snopt::snseti_(strOpt10,&major_print_level,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
     mxGetString(pprint_name,print_file_name,print_file_name_len);
     snopt::snopenappend_(&iPrint,print_file_name,&INFO_snopt,print_file_name_len);
 		char strOpt11[200] = "Print file";
 		strOpt_len = strlen(strOpt11);
-		snopt::snseti_(strOpt11,&iPrint,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+		snopt::snseti_(strOpt11,&iPrint,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
   }
 
   snopt::sninit_(&iPrint,&iSumm,cw,&lencw,iw,&leniw,rw,&lenrw,8*500);
@@ -164,67 +164,67 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
   char strOpt2[200] = "Major iterations limit";
   strOpt_len = strlen(strOpt2);
   snopt::integer major_iterations_limit = static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"MajorIterationsLimit")));
-  snopt::snseti_(strOpt2,&major_iterations_limit,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt2,&major_iterations_limit,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt3[200] = "Minor iterations limit";
   strOpt_len = strlen(strOpt3);
   snopt::integer minor_iterations_limit = static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"MinorIterationsLimit")));
-  snopt::snseti_(strOpt3,&minor_iterations_limit,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt3,&minor_iterations_limit,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt4[200] = "Major optimality tolerance";
   strOpt_len = strlen(strOpt4);
   snopt::doublereal major_optimality_tolerance= static_cast<snopt::doublereal>(*mxGetPr(mxGetField(prhs[13],0,"MajorOptimalityTolerance")));
-  snopt::snsetr_(strOpt4,&major_optimality_tolerance,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snsetr_(strOpt4,&major_optimality_tolerance,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt5[200] = "Major feasibility tolerance";
   strOpt_len = strlen(strOpt5);
   snopt::doublereal major_feasibility_tolerance= static_cast<snopt::doublereal>(*mxGetPr(mxGetField(prhs[13],0,"MajorFeasibilityTolerance")));
-  snopt::snsetr_(strOpt5,&major_feasibility_tolerance,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
-  
+  snopt::snsetr_(strOpt5,&major_feasibility_tolerance,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
+
   char strOpt6[200] = "Minor feasibility tolerance";
   strOpt_len = strlen(strOpt6);
   snopt::doublereal minor_feasibility_tolerance= static_cast<snopt::doublereal>(*mxGetPr(mxGetField(prhs[13],0,"MinorFeasibilityTolerance")));
-  snopt::snsetr_(strOpt6,&minor_feasibility_tolerance,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
-  
+  snopt::snsetr_(strOpt6,&minor_feasibility_tolerance,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
+
   char strOpt7[200] = "Superbasics limit";
   strOpt_len = strlen(strOpt7);
   snopt::integer superbasics_limit = static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"SuperbasicsLimit")));
-  snopt::snseti_(strOpt7,&superbasics_limit,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt7,&superbasics_limit,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt8[200] = "Verify level";
   strOpt_len = strlen(strOpt8);
   snopt::integer verify_level = static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"VerifyLevel")));
-  snopt::snseti_(strOpt8,&verify_level,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt8,&verify_level,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt9[200] = "Iterations Limit";
   strOpt_len = strlen(strOpt9);
   snopt::integer iterations_limit = static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"IterationsLimit")));
-  snopt::snseti_(strOpt9,&iterations_limit,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt9,&iterations_limit,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt11[200] = "Scale option";
   strOpt_len = strlen(strOpt11);
   snopt::integer scale_option= static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"ScaleOption")));
-  snopt::snseti_(strOpt11,&scale_option,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt11,&scale_option,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt12[200] = "New basis file";
   strOpt_len = strlen(strOpt12);
   snopt::integer new_basis_file = static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"NewBasisFile")));
-  snopt::snseti_(strOpt12,&new_basis_file,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt12,&new_basis_file,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt13[200] = "Old basis file";
   strOpt_len = strlen(strOpt13);
   snopt::integer old_basis_file = static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"OldBasisFile")));
-  snopt::snseti_(strOpt13,&old_basis_file,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt13,&old_basis_file,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt14[200] = "Backup basis file";
   strOpt_len = strlen(strOpt14);
   snopt::integer backup_basis_file = static_cast<snopt::integer>(*mxGetPr(mxGetField(prhs[13],0,"BackupBasisFile")));
-  snopt::snseti_(strOpt14,&backup_basis_file,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snseti_(strOpt14,&backup_basis_file,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   char strOpt15[200] = "Linesearch tolerance";
   strOpt_len = strlen(strOpt15);
   snopt::doublereal line_search_tolerance= static_cast<snopt::doublereal>(*mxGetPr(mxGetField(prhs[13],0,"LinesearchTolerance")));
-  snopt::snsetr_(strOpt15,&line_search_tolerance,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500); 
+  snopt::snsetr_(strOpt15,&line_search_tolerance,&iPrint,&iSumm,&INFO_snopt,cw,&lencw,iw,&leniw,rw,&lenrw,strOpt_len,8*500);
 
   snopt::snopta_
     ( &Cold, &nF, &nx, &nxname, &nFname,
@@ -261,10 +261,16 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
   delete[] Flow;
   delete[] Fupp;
   delete[] snopt_userfun_name;
-  delete[] A,iAfun,jAvar;
-  delete[] iGfun,jGvar;
-  delete[] xmul,xstate;
-  delete[] F,Fmul,Fstate;
+  delete[] A;
+  delete[] iAfun;
+  delete[] jAvar;
+  delete[] iGfun;
+  delete[] jGvar;
+  delete[] xmul;
+  delete[] xstate;
+  delete[] F;
+  delete[] Fmul;
+  delete[] Fstate;
   if(print_file_name_len!= 0)
   {
     snopt::snclose_(&iPrint);


### PR DESCRIPTION
sorry for the few extra whitespace changes (from my editor).  
the content changes were changing the `delete[] a,b` syntax to `delete[] a; delete[] b;` and generlizing the cmake code for finding gfortran.
