### PR TITLE
Avoid MaybeGetValue in control flow, per GSG

### DIFF
--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -13,9 +13,9 @@ MathematicalProgramResult::MathematicalProgramResult()
     : solution_result_{SolutionResult::kUnknownError},
       x_val_{0},
       optimal_cost_{NAN},
-      solver_id_{UnknownId()},
-      solver_details_{
-          systems::AbstractValue::Make<NoSolverDetails>(NoSolverDetails())} {}
+      solver_id_{UnknownId()} {
+  this->SetSolverDetailsType<NoSolverDetails>();
+}
 
 const systems::AbstractValue& MathematicalProgramResult::get_solver_details()
     const {


### PR DESCRIPTION
Making a patch was easier than explaining this one.  Per http://drake.mit.edu/styleguide/cppguide.html#Run-Time_Type_Information__RTTI_, we cannot use MaybeGetValue during production control flow -- only for error checking or error messages.  This patch fixes the problem.