### PR TITLE
fixup!

### DIFF
--- a/math/soft_min_max.cc
+++ b/math/soft_min_max.cc
@@ -1,108 +1,88 @@
 #include "drake/math/soft_min_max.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include "drake/common/default_scalars.h"
+#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace math {
 namespace {
-/** Computes log(∑exp(xᵢ)). Exploits the shift invariance of log-sum-exp to
-avoid overflow. */
+using std::exp;
+using std::isfinite;
+using std::log;
+
+/* We use tare_x to exploit the shift invariance of log-sum-exp to avoid
+overflow. It should be set to the extremum of x (i.e., max when alpha > 0,
+min when alpha < 0). */
 template <typename T>
-T LogSumExp(const std::vector<T>& x) {
-  DRAKE_ASSERT(x.size() > 0);
-  using std::exp;
-  using std::log;
-  const T x_max = *std::max_element(x.begin(), x.end());
-  T sum_exp{0.0};
+T SoftOverMaxImpl(const std::vector<T>& x, double tare_x, double alpha) {
+  T sum_exp{0};
   for (const T& xi : x) {
-    sum_exp += exp(xi - x_max);
+    sum_exp += exp(alpha * (xi - tare_x));
   }
-  return x_max + log(sum_exp);
+  return log(sum_exp) / alpha + tare_x;
+}
+
+/* We use tare_x to avoid overflow. It should be set to the extremum of x
+(i.e., max when alpha > 0, min when alpha < 0). */
+template <typename T>
+T SoftUnderMaxImpl(const std::vector<T>& x, double tare_x, double alpha) {
+  T soft_max{0};
+  T sum_exp{0};
+  for (const T& xi : x) {
+    T exp_xi = exp(alpha * (xi - tare_x));
+    sum_exp += exp_xi;
+    exp_xi *= xi;
+    soft_max += exp_xi;
+  }
+  return soft_max / sum_exp;
 }
 }  // namespace
 
-/**
- Computes a smooth over approximation of max function, namely SoftOverMax(x) >=
- max(x).
- Mathematically we compute this as (log (∑ᵢ exp(αxᵢ))) / α.
- @param x The vector we want to compute its soft max.
- @param alpha α in the documentation above. Larger α makes the soft max more
- similar to max, with a sharper corner.
- @throws std::exception if α <= 0.
- */
 template <typename T>
-[[nodiscard]] T SoftOverMax(const std::vector<T>& x, double alpha) {
-  DRAKE_ASSERT(x.size() > 0);
+T SoftOverMax(const std::vector<T>& x, double alpha) {
+  DRAKE_THROW_UNLESS(x.size() > 0);
   DRAKE_THROW_UNLESS(alpha > 0);
-  if (alpha == 1.0) {
-    return LogSumExp(x);
-  }
-  std::vector<T> x_scaled{x};
-  for (T& xi_scaled : x_scaled) {
-    xi_scaled *= alpha;
-  }
-  return LogSumExp(x_scaled) / alpha;
+  DRAKE_THROW_UNLESS(std::isfinite(alpha));
+  const double max_x =
+      ExtractDoubleOrThrow(*std::max_element(x.begin(), x.end()));
+  return SoftOverMaxImpl(x, max_x, alpha);
 }
 
-/**
- Computes a smooth under approximation of max function, namely SoftUnderMax(x)
- <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ) / d, where d = ∑ⱼ
- exp(αxⱼ)
- @param x The vector we want to compute its soft max.
- @param alpha α in the documentation above. Larger α makes the soft max more
- similar to max, with a sharper corner.
- @throws std::exception if α <= 0.
- */
 template <typename T>
-[[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha) {
-  DRAKE_ASSERT(x.size() > 0);
+T SoftUnderMax(const std::vector<T>& x, double alpha) {
+  DRAKE_THROW_UNLESS(x.size() > 0);
   DRAKE_THROW_UNLESS(alpha > 0);
-  std::vector<T> x_scaled{x};
-  for (auto& xi_scaled : x_scaled) {
-    xi_scaled *= alpha;
-  }
-  // To avoid overflow, we subtract x_scaled_max.
-  const T x_scaled_max = *std::max_element(x_scaled.begin(), x_scaled.end());
-  T soft_max{0};
-  T d{0};
-  for (int i = 0; i < static_cast<int>(x.size()); ++i) {
-    using std::exp;
-    const T exp_xi = exp(x_scaled[i] - x_scaled_max);
-    soft_max += exp_xi * x[i];
-    d += exp_xi;
-  }
-  return soft_max / d;
-}
-
-/**
- Computes a smooth over approximation of max function, namely SoftOverMin(x) >=
- min(x).
- Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ) / d, where d = ∑ⱼ
- exp(-αxⱼ)
- @param x The vector we want to compute its soft min.
- @param alpha α in the documentation above. Larger α makes the soft min more
- similar to min, with a sharper corner.
- @throws std::exception if α <= 0.
- */
-template <typename T>
-[[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha) {
-  // min(x) = -max(-x)
-  std::vector<T> x_negate{x};
-  for (auto& xi : x_negate) {
-    xi *= -1;
-  }
-  return -SoftUnderMax(x_negate, alpha);
+  DRAKE_THROW_UNLESS(std::isfinite(alpha));
+  const double max_x =
+      ExtractDoubleOrThrow(*std::max_element(x.begin(), x.end()));
+  return SoftUnderMaxImpl(x, max_x, alpha);
 }
 
 template <typename T>
-[[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha) {
+T SoftOverMin(const std::vector<T>& x, double alpha) {
+  DRAKE_THROW_UNLESS(x.size() > 0);
+  DRAKE_THROW_UNLESS(alpha > 0);
+  DRAKE_THROW_UNLESS(std::isfinite(alpha));
   // min(x) = -max(-x)
-  std::vector<T> x_negate{x};
-  for (auto& xi : x_negate) {
-    xi *= -1;
-  }
-  return -SoftOverMax(x_negate, alpha);
+  const double min_x =
+      ExtractDoubleOrThrow(*std::min_element(x.begin(), x.end()));
+  return SoftUnderMaxImpl(x, min_x, -alpha);
 }
+
+template <typename T>
+T SoftUnderMin(const std::vector<T>& x, double alpha) {
+  DRAKE_THROW_UNLESS(x.size() > 0);
+  DRAKE_THROW_UNLESS(alpha > 0);
+  DRAKE_THROW_UNLESS(std::isfinite(alpha));
+  // min(x) = -max(-x)
+  const double min_x =
+      ExtractDoubleOrThrow(*std::min_element(x.begin(), x.end()));
+  return SoftOverMaxImpl(x, min_x, -alpha);
+}
+
 // Explicit instantiation
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     (&SoftOverMax<T>, &SoftUnderMax<T>, &SoftOverMin<T>, &SoftUnderMin<T>))

--- a/math/soft_min_max.h
+++ b/math/soft_min_max.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include <algorithm>
-#include <cmath>
 #include <vector>
-
-#include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace math {
@@ -17,34 +12,34 @@ namespace math {
  @param alpha α in the documentation above. Larger α makes the soft max more
  similar to max, with a sharper corner.
  @throws std::exception if α <= 0.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
 [[nodiscard]] T SoftOverMax(const std::vector<T>& x, double alpha = 1.0);
 
 /**
  Computes a smooth under approximation of max function, namely SoftUnderMax(x)
- <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ) / d, where d = ∑ⱼ
+ <= max(x). Mathematically we compute this as ∑ᵢ exp(αxᵢ)*xᵢ / d, where d = ∑ⱼ
  exp(αxⱼ)
  @param x The vector we want to compute its soft max.
  @param alpha α in the documentation above. Larger α makes the soft max more
  similar to max, with a sharper corner.
  @throws std::exception if α <= 0.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
-[[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha = 1);
+[[nodiscard]] T SoftUnderMax(const std::vector<T>& x, double alpha = 1.0);
 
 /**
  Computes a smooth over approximation of min function, namely SoftOverMin(x) >=
  min(x).
- Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ) / d, where d = ∑ⱼ
+ Mathematically we compute this as ∑ᵢ exp(-αxᵢ)*xᵢ / d, where d = ∑ⱼ
  exp(-αxⱼ)
  @param x The vector we want to compute its soft min.
  @param alpha α in the documentation above. Larger α makes the soft min more
  similar to min, with a sharper corner.
  @throws std::exception if α <= 0.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
-[[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha = 1);
+[[nodiscard]] T SoftOverMin(const std::vector<T>& x, double alpha = 1.0);
 
 /**
  Computes a smooth under approximation of max function, namely SoftUnderMin(x)
@@ -53,8 +48,8 @@ template <typename T>
  @param alpha α in the documentation above. Larger α makes the soft min more
  similar to min, with a sharper corner.
  @throws std::exception if α <= 0.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
-[[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha = 1);
+[[nodiscard]] T SoftUnderMin(const std::vector<T>& x, double alpha = 1.0);
 }  // namespace math
 }  // namespace drake


### PR DESCRIPTION
For https://github.com/RobotLocomotion/drake/pull/19591.

- Use DRAKE_THROW_UNLESS when checking user input (unless its way too slow, but that's not the case here).
- Use DRAKE_THROW_UNLESS inside the function the user calls; relying on indirect checking means the function name will be wrong in the error message.
- Don't allocate extra vectors for scaling or negating; just do that via an argument to a helper function.
- Micro-optimize to avoid extra copies of partials:
```
    exp_xi *= xi;
    soft_max += exp_xi;
```